### PR TITLE
Exact words

### DIFF
--- a/c-shared.c
+++ b/c-shared.c
@@ -12,9 +12,10 @@ Suggestion* makeSuggestion(char* word, int weight, int learned_on)
   return sug;
 }
 
-TransliterationResult* makeResult(varray* exact_matches, varray* dictionary_suggestions, varray* pattern_dictionary_suggestions, varray* tokenizer_suggestions, varray* greedy_tokenized)
+TransliterationResult* makeResult(varray* exact_words, varray* exact_matches, varray* dictionary_suggestions, varray* pattern_dictionary_suggestions, varray* tokenizer_suggestions, varray* greedy_tokenized)
 {
   TransliterationResult *result = (TransliterationResult*) malloc (sizeof(TransliterationResult));
+  result->ExactWords = exact_words;
   result->ExactMatches = exact_matches;
   result->DictionarySuggestions = dictionary_suggestions;
   result->PatternDictionarySuggestions = pattern_dictionary_suggestions;

--- a/c-shared.go
+++ b/c-shared.go
@@ -65,10 +65,16 @@ func makeCTransliterationResult(ctx context.Context, goResult govarnam.Translite
 		// They should be freed manually. GC won't pick it.
 		// The freeing should be done by programs using govarnam
 
-		cExactMatch := C.varray_init()
+		cExactWords := C.varray_init()
+		for _, sug := range goResult.ExactWords {
+			cSug := unsafe.Pointer(C.makeSuggestion(C.CString(sug.Word), C.int(sug.Weight), C.int(sug.LearnedOn)))
+			C.varray_push(cExactWords, cSug)
+		}
+
+		cExactMatches := C.varray_init()
 		for _, sug := range goResult.ExactMatches {
 			cSug := unsafe.Pointer(C.makeSuggestion(C.CString(sug.Word), C.int(sug.Weight), C.int(sug.LearnedOn)))
-			C.varray_push(cExactMatch, cSug)
+			C.varray_push(cExactMatches, cSug)
 		}
 
 		cDictionarySuggestions := C.varray_init()
@@ -95,7 +101,7 @@ func makeCTransliterationResult(ctx context.Context, goResult govarnam.Translite
 			C.varray_push(cGreedyTokenized, cSug)
 		}
 
-		*resultPointer = C.makeResult(cExactMatch, cDictionarySuggestions, cPatternDictionarySuggestions, cTokenizerSuggestions, cGreedyTokenized)
+		*resultPointer = C.makeResult(cExactWords, cExactMatches, cDictionarySuggestions, cPatternDictionarySuggestions, cTokenizerSuggestions, cGreedyTokenized)
 
 		return C.VARNAM_SUCCESS
 	}

--- a/c-shared.h
+++ b/c-shared.h
@@ -25,6 +25,7 @@ typedef struct Suggestion_t {
 } Suggestion;
 
 typedef struct TransliterationResult_t {
+  varray* ExactWords;
   varray* ExactMatches;
   varray* DictionarySuggestions;
   varray* PatternDictionarySuggestions;
@@ -34,7 +35,7 @@ typedef struct TransliterationResult_t {
 
 Suggestion* makeSuggestion(char* word, int weight, int learned_on);
 
-TransliterationResult* makeResult(varray* exact_matches, varray* dictionary_suggestions, varray* pattern_dictionary_suggestions, varray* tokenizer_suggestions, varray* greedy_tokenized);
+TransliterationResult* makeResult(varray* exact_words, varray* exact_matches, varray* dictionary_suggestions, varray* pattern_dictionary_suggestions, varray* tokenizer_suggestions, varray* greedy_tokenized);
 
 void destroySuggestionsArray(varray* pointer);
 void destroyTransliterationResult(TransliterationResult*);

--- a/cli/main.go
+++ b/cli/main.go
@@ -169,6 +169,9 @@ func main() {
 		fmt.Println("Greedy Tokenized")
 		printSugs(result.GreedyTokenized)
 
+		fmt.Println("Exact Words")
+		printSugs(result.ExactWords)
+
 		fmt.Println("Exact Matches")
 		printSugs(result.ExactMatches)
 

--- a/govarnam/channel.go
+++ b/govarnam/channel.go
@@ -204,13 +204,13 @@ func (varnam *Varnam) channelGetFromPatternDictionary(ctx context.Context, word 
 				perMatchLimit = perMatchLimit / len(partialMatches)
 			}
 
-			for _, match := range partialMatches {
-				restOfWord := word[match.Length:]
+			for i := range partialMatches {
+				restOfWord := word[partialMatches[i].Length:]
 
 				filled := varnam.tokenizeRestOfWord(
 					ctx,
 					restOfWord,
-					[]Suggestion{match.Sug},
+					[]Suggestion{partialMatches[i].Sug},
 					perMatchLimit,
 				)
 

--- a/govarnam/govarnam.go
+++ b/govarnam/govarnam.go
@@ -331,7 +331,7 @@ func (varnam *Varnam) transliterate(ctx context.Context, word string) (
 				return nil, result
 			case channelPatternDictResult := <-patternDictSugsChan:
 				// From patterns dictionary
-				result.ExactMatches = append(result.ExactMatches, channelPatternDictResult.exactMatches...)
+				result.ExactWords = append(result.ExactWords, channelPatternDictResult.exactWords...)
 				result.PatternDictionarySuggestions = SortSuggestions(channelPatternDictResult.suggestions)
 
 				if len(result.ExactMatches) == 0 || varnam.TokenizerSuggestionsAlways {
@@ -407,7 +407,11 @@ func flattenTR(result TransliterationResult) []Suggestion {
 	var combined []Suggestion
 
 	dictCombined := result.ExactWords
-	dictCombined = append(dictCombined, result.ExactMatches...)
+
+	if len(result.ExactWords) == 0 {
+		dictCombined = append(dictCombined, result.ExactMatches...)
+	}
+
 	dictCombined = append(dictCombined, result.PatternDictionarySuggestions...)
 	dictCombined = append(dictCombined, result.DictionarySuggestions...)
 

--- a/govarnam/govarnam.go
+++ b/govarnam/govarnam.go
@@ -91,10 +91,11 @@ type Suggestion struct {
 // TransliterationResult result
 type TransliterationResult struct {
 	// Exactly found words in dictionary if there is any.
+	// From both patterns and normal dict
 	ExactWords []Suggestion
 
-	// Exact matches found in dictionary if there is any.
-	// From both patterns and normal dict
+	// Exactly starting word matches in dictionary if there is any.
+	// Not applicable for patterns dictionary.
 	ExactMatches []Suggestion
 
 	// Possible word suggestions from dictionary

--- a/govarnam/govarnam.go
+++ b/govarnam/govarnam.go
@@ -485,8 +485,8 @@ func (varnam *Varnam) ReverseTransliterate(word string) ([]Suggestion, error) {
 		fmt.Println(tokens)
 	}
 
-	for i, token := range tokens {
-		for j, symbol := range token.symbols {
+	for i := range tokens {
+		for j, symbol := range tokens[i].symbols {
 			tokens[i].symbols[j].Value1 = symbol.Pattern
 			tokens[i].symbols[j].Value2 = symbol.Pattern
 		}

--- a/govarnam/govarnam_ml_test.go
+++ b/govarnam/govarnam_ml_test.go
@@ -151,6 +151,7 @@ func TestMLTrain(t *testing.T) {
 	checkError(err)
 
 	assertEqual(t, varnam.TransliterateAdvanced("india").ExactWords[0].Word, "ഇന്ത്യ")
+	assertEqual(t, varnam.TransliterateAdvanced("ind").PatternDictionarySuggestions[0].Word, "ഇന്ത്യ")
 	assertEqual(t, varnam.TransliterateAdvanced("indiayil").PatternDictionarySuggestions[0].Word, "ഇന്ത്യയിൽ")
 
 	// Word with virama at end

--- a/govarnam/symbol.go
+++ b/govarnam/symbol.go
@@ -470,9 +470,9 @@ func getSymbolWeight(symbol Symbol) int {
 
 // Removes less weighted symbols
 func removeLessWeightedSymbols(tokens []Token) []Token {
-	for i, token := range tokens {
+	for i := range tokens {
 		var reducedSymbols []Symbol
-		for _, symbol := range token.symbols {
+		for _, symbol := range tokens[i].symbols {
 			// TODO should 0 be fixed for all languages ?
 			// Because this may differ according to data source
 			// from where symbol frequency was found out

--- a/govarnamgo/govarnamgo.go
+++ b/govarnamgo/govarnamgo.go
@@ -44,6 +44,7 @@ type Suggestion struct {
 
 // TransliterationResult result
 type TransliterationResult struct {
+	ExactWords                   []Suggestion
 	ExactMatches                 []Suggestion
 	DictionarySuggestions        []Suggestion
 	PatternDictionarySuggestions []Suggestion
@@ -110,6 +111,16 @@ func makeGoTransliterationResult(ctx context.Context, cResult *C.struct_Translit
 		return result
 	default:
 		var i int
+
+		var exactWords []Suggestion
+		i = 0
+		for i < int(C.varray_length(cResult.ExactWords)) {
+			cSug := (*C.Suggestion)(C.varray_get(cResult.ExactWords, C.int(i)))
+			sug := makeSuggestion(cSug)
+			exactWords = append(exactWords, sug)
+			i++
+		}
+		result.ExactWords = exactWords
 
 		var exactMatches []Suggestion
 		i = 0

--- a/govarnamgo/govarnamgo_ml_test.go
+++ b/govarnamgo/govarnamgo_ml_test.go
@@ -66,9 +66,9 @@ func TestLearn(t *testing.T) {
 	assertEqual(t, learnStatus.FailedWords, 1)
 
 	result, err := varnam.TransliterateAdvanced(context.Background(), "nithyaharitha")
-	assertEqual(t, result.ExactMatches[0].Weight, 120)
+	assertEqual(t, result.ExactWords[0].Weight, 120)
 	result, err = varnam.TransliterateAdvanced(context.Background(), "melaappum")
-	assertEqual(t, result.ExactMatches[0].Weight, 12)
+	assertEqual(t, result.ExactWords[0].Weight, 12)
 }
 
 func TestRecentlyLearnedWords(t *testing.T) {


### PR DESCRIPTION
Fixes #21 

* Adds a new higher prioirty `ExactWords` result along with `ExactMatches`. How it differs:
  * ExactWords - Exactly found words in dictionary if there is any.
  * ExactMatches - Exactly starting word matches in dictionary if there is any. Not applicable for patterns dictionary.
* Avoid item variable in range loops to save memory copying wherever possible. `for i, item := range` to `for i := range`