### PR TITLE
build: Set a soname on the library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ temp-pc:
 	${SED} "s#@VERSION@#${VERSION}#g" govarnam.pc
 
 	${SED} "s#/include/libgovarnam##g" govarnam.pc
-	${SED} "s#/lib##g" govarnam.pc
+	${SED} "s#/lib\$$##g" govarnam.pc
 
 install-script:
 	cp install.sh.in install.sh

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LIB_NAME := libgovarnam.so
 
 ifeq ($(UNAME), Darwin)
   SED := sed -i ""
-	LIB_NAME = libgovarnam.dylib
+  LIB_NAME = libgovarnam.dylib
 endif
 
 VERSION_STAMP_LDFLAGS := -X 'github.com/varnamproject/govarnam/govarnam.BuildString=${BUILDSTR}' -X 'github.com/varnamproject/govarnam/govarnam.VersionString=${VERSION}'

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,16 @@ UNAME := $(shell uname)
 
 SED := sed -i
 LIB_NAME := libgovarnam.so
+SO_NAME := $(shell (echo $(VERSION) | cut -d. -f1))
 
 ifeq ($(UNAME), Darwin)
   SED := sed -i ""
   LIB_NAME = libgovarnam.dylib
+else
+  EXT_LDFLAGS = -extldflags -Wl,-soname,$(LIB_NAME).$(SO_NAME)
 endif
 
-VERSION_STAMP_LDFLAGS := -X 'github.com/varnamproject/govarnam/govarnam.BuildString=${BUILDSTR}' -X 'github.com/varnamproject/govarnam/govarnam.VersionString=${VERSION}'
-
+VERSION_STAMP_LDFLAGS := -X 'github.com/varnamproject/govarnam/govarnam.BuildString=${BUILDSTR}' -X 'github.com/varnamproject/govarnam/govarnam.VersionString=${VERSION}' $(EXT_LDFLAGS)
 pc:
 	cp govarnam.pc.in govarnam.pc
 	${SED} "s#@INSTALL_PREFIX@#${INSTALL_PREFIX}#g" govarnam.pc


### PR DESCRIPTION
This sets an soname for dynamic linking:

```    
      $ readelf -a libgovarnam.so | grep SONAME
      0x000000000000000e (SONAME)             Library soname: [libgovarnam.so.1]
```   
 
This is needed for ABI versioning and dynamlic linking. See e.g.
Section 8.1 of Debian's policy.
    
 With this one gets properly versioned dependencies e.g.
   
``` 
      $ readelf -a _build/src/phosh-osk-stub | grep gov
      0x0000000000000001 (NEEDED)             Shared library: [libgovarnam.so.1]
```   
 
While without that patch one gets an unversioned dependency which won't
 allow to handle any ABI changes:

```    
      $ readelf -a _build/src/phosh-osk-stub | grep libgovarn
      0x0000000000000001 (NEEDED)             Shared library: [/usr/local/lib/libgovarnam.so]
```

This includes the changes from #31 as otherwise there will be merge conflicts.