### PR TITLE
build: Set soname on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SO_NAME := $(shell (echo $(VERSION) | cut -d. -f1))
 ifeq ($(UNAME), Darwin)
   SED := sed -i ""
   LIB_NAME = libgovarnam.dylib
+else
   EXT_LDFLAGS = -extldflags -Wl,-soname,$(LIB_NAME).$(SO_NAME)
 endif
 


### PR DESCRIPTION
The merge of PR #33  dropped `else` which made the soname setting ineffective on Linux (and would apply it on Darwin instead).

My original push had the `else` but it got dropped in https://github.com/varnamproject/govarnam/pull/33/commits/36dc05e7c9e628e0bf0f1a755407e543dbbbb531 . 
