### PR TITLE
Limit exported symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,13 @@ UNAME := $(shell uname)
 SED := sed -i
 LIB_NAME := libgovarnam.so
 SO_NAME := $(shell (echo $(VERSION) | cut -d. -f1))
+CURDIR := $(shell pwd)
 
 ifeq ($(UNAME), Darwin)
   SED := sed -i ""
   LIB_NAME = libgovarnam.dylib
 else
-  EXT_LDFLAGS = -extldflags -Wl,-soname,$(LIB_NAME).$(SO_NAME)
+  EXT_LDFLAGS = -extldflags "-Wl,-soname,$(LIB_NAME).$(SO_NAME),--version-script,$(CURDIR)/govarnam.syms"
 endif
 
 VERSION_STAMP_LDFLAGS := -X 'github.com/varnamproject/govarnam/govarnam.BuildString=${BUILDSTR}' -X 'github.com/varnamproject/govarnam/govarnam.VersionString=${VERSION}' $(EXT_LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SO_NAME := $(shell (echo $(VERSION) | cut -d. -f1))
 ifeq ($(UNAME), Darwin)
   SED := sed -i ""
   LIB_NAME = libgovarnam.dylib
+else
   EXT_LDFLAGS = -extldflags -Wl,-soname,$(LIB_NAME).$(SO_NAME)
 endif
 

--- a/govarnam.syms
+++ b/govarnam.syms
@@ -1,0 +1,9 @@
+{
+        global:
+                varnam_*;
+                varray_*;
+                vm_*;
+        local:
+                *;
+};
+


### PR DESCRIPTION
This greatly reduces the number of exported symbols by limiting the namespace of exported symbols to {varnam,varray,vm}_ thus avoiding the export of all the `_cg` symbols from go.
    
Before:
    
```
    $ readelf -s /usr/lib/libgovarnam.so.1.9.0  | grep -v " UND " | wc -l
    248
```   
 
After:
   
``` 
    $ readelf -s /usr/lib/libgovarnam.so.1.9.0  | grep -v " UND " | wc -l
    52
```   
 
With this we can make sure applications don't link against accidentally exported symbols and break on library upgrades without us being able to notice. It also allows us to notice when symbols go missing and we hence need to bump the ABI version.

I've put this on top of #34 

This also allows us to use symbol versioning for new symbols if desired.