### PR TITLE
Allow to configure more dirs

### DIFF
--- a/govarnam.pc.in
+++ b/govarnam.pc.in
@@ -1,6 +1,6 @@
 prefix=@INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${prefix}@LIBDIR@
 includedir=${prefix}/include/libgovarnam
 
 Name: GoVarnam

--- a/install.sh.in
+++ b/install.sh.in
@@ -9,7 +9,9 @@ SUDO=${SUDO:-sudo}
 
 if [ "$ARG1" == "install" ]; then
   "${SUDO}" mkdir -p "/usr/local/bin/"
-  "${SUDO}" cp "$SCRIPT_DIR/varnamcli" "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli"
+  if [ -f $SCRIPT_DIR/varnamcli ]; then
+    "${SUDO}" cp "$SCRIPT_DIR/varnamcli" "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli"
+  fi
   
   "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig"
   "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@"

--- a/install.sh.in
+++ b/install.sh.in
@@ -9,29 +9,29 @@ SUDO=${SUDO:-sudo}
 
 if [ "$ARG1" == "install" ]; then
   "${SUDO}" mkdir -p "/usr/local/bin/"
-  "${SUDO}" cp "$SCRIPT_DIR/varnamcli" "@INSTALL_PREFIX@/bin/varnamcli"
+  "${SUDO}" cp "$SCRIPT_DIR/varnamcli" "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli"
   
-  "${SUDO}" mkdir -p "@INSTALL_PREFIX@/lib/pkgconfig"
-  "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@"
-  "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@"
-  "${SUDO}" cp "$SCRIPT_DIR/govarnam.pc" "@INSTALL_PREFIX@/lib/pkgconfig/"
+  "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig"
+  "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@"
+  "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@"
+  "${SUDO}" cp "$SCRIPT_DIR/govarnam.pc" "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig/"
 
-  "${SUDO}" mkdir -p "@INSTALL_PREFIX@/include/libgovarnam"
-  "${SUDO}" cp "$SCRIPT_DIR/"*.h "@INSTALL_PREFIX@/include/libgovarnam/"
+  "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam"
+  "${SUDO}" cp "$SCRIPT_DIR/"*.h "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam/"
   "${SUDO}" ldconfig || true
 
-  "${SUDO}" mkdir -p "@INSTALL_PREFIX@/share/varnam/schemes"
+  "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@/share/varnam/schemes"
 
   msg="Installation finished"
   echo "$msg"
 
   notify-send "$msg" &> /dev/null || true
 elif [ "$ARG1" == "uninstall" ]; then
-  "${SUDO}" rm "@INSTALL_PREFIX@/bin/varnamcli" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@" "@INSTALL_PREFIX@/lib/pkgconfig/govarnam.pc"
-  "${SUDO}" rm "@INSTALL_PREFIX@/include/libgovarnam/"*
-  "${SUDO}" rmdir "@INSTALL_PREFIX@/include/libgovarnam"
-  "${SUDO}" rm "@INSTALL_PREFIX@/share/varnam/schemes/"*
-  "${SUDO}" rmdir "@INSTALL_PREFIX@/share/varnam/schemes/"
+  "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig/govarnam.pc"
+  "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam/"*
+  "${SUDO}" rmdir "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam"
+  "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/share/varnam/schemes/"*
+  "${SUDO}" rmdir "${DESTDIR}@INSTALL_PREFIX@/share/varnam/schemes/"
 
   msg="Uninstallation finished"
   echo $msg

--- a/install.sh.in
+++ b/install.sh.in
@@ -13,10 +13,10 @@ if [ "$ARG1" == "install" ]; then
     "${SUDO}" cp "$SCRIPT_DIR/varnamcli" "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli"
   fi
   
-  "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig"
-  "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@"
-  "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@"
-  "${SUDO}" cp "$SCRIPT_DIR/govarnam.pc" "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig/"
+  "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/pkgconfig"
+  "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/@LIB_NAME@.@VERSION@"
+  "${SUDO}" ln -s "@INSTALL_PREFIX@@LIBDIR@/@LIB_NAME@.@VERSION@" "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/@LIB_NAME@"
+  "${SUDO}" cp "$SCRIPT_DIR/govarnam.pc" "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/pkgconfig/"
 
   "${SUDO}" mkdir -p "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam"
   "${SUDO}" cp "$SCRIPT_DIR/"*.h "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam/"
@@ -29,7 +29,7 @@ if [ "$ARG1" == "install" ]; then
 
   notify-send "$msg" &> /dev/null || true
 elif [ "$ARG1" == "uninstall" ]; then
-  "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "${DESTDIR}@INSTALL_PREFIX@/lib/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@/lib/pkgconfig/govarnam.pc"
+  "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/bin/varnamcli" "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/@LIB_NAME@.@VERSION@" "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/@LIB_NAME@" "${DESTDIR}@INSTALL_PREFIX@@LIBDIR@/pkgconfig/govarnam.pc"
   "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam/"*
   "${SUDO}" rmdir "${DESTDIR}@INSTALL_PREFIX@/include/libgovarnam"
   "${SUDO}" rm "${DESTDIR}@INSTALL_PREFIX@/share/varnam/schemes/"*


### PR DESCRIPTION
These patches allow to:

- add a `${DESTDIR}`. This is needed for distro packaging where you install into
  `/whatever/build/dir/usr/lib/libgovarnam.so.1.9.0` but want the path on the installed system to be `/usr/lib/libgovarnam.so.1.9.0`.
- alllow to set `libdir`. This is needed for multiarch installs where you want the libs to be in `/usr/lib/<architecture>/libvarnam.so.1.9.0
- allow to skip the cli install (for the case where it's not built)
- instead of changing the files via `sed` multiple times we use one call. In order to avoid problems when running out of diskspace we create a temp file and move that into place.

With these I can build a policy conformant library package for Debian. 