### PR TITLE
export required symbols

### DIFF
--- a/govarnam.syms
+++ b/govarnam.syms
@@ -3,6 +3,8 @@
                 varnam_*;
                 varray_*;
                 vm_*;
+		makeSymbol;
+		destroy*;
         local:
                 *;
 };


### PR DESCRIPTION
Commit 436d0066819f1b7f5a50f3d458b1ca056ac74f1a limits exported symbols, resulting the following functions unexported.

* makeSymbol
* destroySchemeDetailsArray
* destroySuggestionsArray
* destroySymbolArray
* destroyTransliterationResult

Beacuse of this, building cli fails

/usr/lib/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/sbin/ld: /tmp/go-link-3522484544/000002.o: in function `_cgo_583732af04bd_Cfunc_makeSymbol':
/tmp/go-build/govarnamgo.cgo2.c:124:(.text+0x8a): undefined reference to `makeSymbol'
/sbin/ld: /tmp/go-link-3522484544/000002.o: in function `_cgo_583732af04bd_Cfunc_destroySchemeDetailsArray':
/tmp/go-build/govarnamgo.cgo2.c:49:(.text+0x4): undefined reference to `destroySchemeDetailsArray'
/sbin/ld: /tmp/go-link-3522484544/000002.o: in function `_cgo_583732af04bd_Cfunc_destroySuggestionsArray':
/tmp/go-build/govarnamgo.cgo2.c:61:(.text+0x14): undefined reference to `destroySuggestionsArray'
/sbin/ld: /tmp/go-link-3522484544/000002.o: in function `_cgo_583732af04bd_Cfunc_destroySymbolArray':
/tmp/go-build/govarnamgo.cgo2.c:73:(.text+0x24): undefined reference to `destroySymbolArray'
/sbin/ld: /tmp/go-link-3522484544/000002.o: in function `_cgo_583732af04bd_Cfunc_destroyTransliterationResult':
/tmp/go-build/govarnamgo.cgo2.c:85:(.text+0x34): undefined reference to `destroyTransliterationResult'