### PR TITLE
symlink libgovarnam -> libgovarnam.so.$SO_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ install-script:
 	${SED} "s#@INSTALL_PREFIX@#${INSTALL_PREFIX}#g" install.sh
 	${SED} "s#@VERSION@#${VERSION}#g" install.sh
 	${SED} "s#@LIB_NAME@#${LIB_NAME}#g" install.sh
+	${SED} "s#@SO_NAME@#${SO_NAME}#g" install.sh
 	chmod +x install.sh
 
 install:
@@ -60,6 +61,7 @@ library-nosqlite:
 
 library:
 	CGO_ENABLED=1 go build -tags "fts5" -buildmode=c-shared -ldflags "-s -w ${VERSION_STAMP_LDFLAGS}" -o ${LIB_NAME} .
+	ln -sf "$(realpath ./)/libgovarnam.so" "$(realpath ./)/libgovarnam.so.${SO_NAME}"
 
 library-mac-universal:
 	GOOS=darwin GOARCH=arm64 $(MAKE) library

--- a/install.sh.in
+++ b/install.sh.in
@@ -14,6 +14,7 @@ if [ "$ARG1" == "install" ]; then
   "${SUDO}" mkdir -p "@INSTALL_PREFIX@/lib/pkgconfig"
   "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@"
   "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@"
+  "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@SO_NAME@"
   "${SUDO}" cp "$SCRIPT_DIR/govarnam.pc" "@INSTALL_PREFIX@/lib/pkgconfig/"
 
   "${SUDO}" mkdir -p "@INSTALL_PREFIX@/include/libgovarnam"

--- a/install.sh.in
+++ b/install.sh.in
@@ -13,8 +13,8 @@ if [ "$ARG1" == "install" ]; then
   
   "${SUDO}" mkdir -p "@INSTALL_PREFIX@/lib/pkgconfig"
   "${SUDO}" cp "$SCRIPT_DIR/@LIB_NAME@" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@"
-  "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@"
-  "${SUDO}" ln -s "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@SO_NAME@"
+  "${SUDO}" ln -sf "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@"
+  "${SUDO}" ln -sf "@INSTALL_PREFIX@/lib/@LIB_NAME@.@VERSION@" "@INSTALL_PREFIX@/lib/@LIB_NAME@.@SO_NAME@"
   "${SUDO}" cp "$SCRIPT_DIR/govarnam.pc" "@INSTALL_PREFIX@/lib/pkgconfig/"
 
   "${SUDO}" mkdir -p "@INSTALL_PREFIX@/include/libgovarnam"


### PR DESCRIPTION
varnamcli looks for libgovarnam.so.SO_NAME and fails
to find any.

ldd varnamcli   | grep libgovarnam
	libgovarnam.so.1 => not found

2 cases

* make library: only libgovarnam.so is compiled,
	so symlink libgovarnam.so -> libgovarnam.so.SO_NAME
	for local varnamcli use.

* make install: symlink libgovarnam.so.VERSION -> libgovarnam.so.SO_NAME

also overwrite existing symlinks during install