### PR TITLE
remove deprecated io/ioutil

### DIFF
--- a/govarnam/govarnam_ml_test.go
+++ b/govarnam/govarnam_ml_test.go
@@ -2,7 +2,6 @@ package govarnam
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"path"
 	"strings"
@@ -377,7 +376,7 @@ func TestMLExportAndImport(t *testing.T) {
 	varnam.Export(exportFileIntendedPath, 300)
 
 	// read the whole file at once
-	b, err := ioutil.ReadFile(exportFilePath)
+	b, err := os.ReadFile(exportFilePath)
 	if err != nil {
 		panic(err)
 	}

--- a/govarnam/govarnam_test.go
+++ b/govarnam/govarnam_test.go
@@ -1,7 +1,6 @@
 package govarnam
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -104,7 +103,7 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	testTempDir, err = ioutil.TempDir("", "govarnam_test")
+	testTempDir, err = os.TempDir("", "govarnam_test")
 	checkError(err)
 
 	for _, schemeDetail := range schemeDetails {

--- a/govarnam/learn.go
+++ b/govarnam/learn.go
@@ -12,7 +12,6 @@ import (
 	sql "database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -624,7 +623,7 @@ func (varnam *Varnam) Export(filePath string, wordsPerFile int) error {
 		jsonData, err := json.Marshal(output)
 
 		filePathWithPageNumber := filePath + "-" + fmt.Sprint(page) + ".vlf"
-		err = ioutil.WriteFile(filePathWithPageNumber, jsonData, 0644)
+		err = os.WriteFile(filePathWithPageNumber, jsonData, 0644)
 		if err != nil {
 			return err
 		}
@@ -642,7 +641,7 @@ func (varnam *Varnam) Import(filePath string) error {
 	}
 
 	// TODO better reading of JSON. This loads entire file into memory
-	fileContent, _ := ioutil.ReadFile(filePath)
+	fileContent, _ := os.ReadFile(filePath)
 
 	var dbData exportFormat
 

--- a/govarnamgo/govarnamgo_test.go
+++ b/govarnamgo/govarnamgo_test.go
@@ -1,7 +1,6 @@
 package govarnamgo
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -68,7 +67,7 @@ func tearDown() {
 
 func TestMain(m *testing.M) {
 	var err error
-	testTempDir, err = ioutil.TempDir("", "govarnam_test")
+	testTempDir, err = os.TempDir("", "govarnam_test")
 	checkError(err)
 
 	setUp("ml")


### PR DESCRIPTION
* ioutil is deprecated since go 1.16
* go version in go.mod is 1.16, so removing won't affect us