### PR TITLE
Enhance Makefile for library and program installation on Linux

### DIFF
--- a/govarnam.pc.in
+++ b/govarnam.pc.in
@@ -1,7 +1,7 @@
-prefix=@INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${prefix}@LIBDIR@
-includedir=${prefix}/include/libgovarnam
+prefix=@PREFIX@
+exec_prefix=@PREFIX@
+libdir=@LIBDIR@
+includedir=@INCLUDEDIR@/libgovarnam
 
 Name: GoVarnam
 Description: A transliteration library for Indian languages


### PR DESCRIPTION
Hello everyone!

I am a maintainer of the ALT Linux distribution (https://www.basealt.ru/en) and the maintainer of your project, Varnam (https://packages.altlinux.org/en/search/?branch=sisyphus&q=varnam).

I received a bug report regarding libgovarnam (https://bugzilla.altlinux.org/54897) (unfortunately, it's in Russian), which made me realize that I should use my experience to help your project achieve a correct Makefile. This will significantly simplify the maintenance of the package and speed up its availability in the repositories of other Linux distributions.

Currently, to build your project, I have to perform the following steps:
```
%make_build
# To comply with the shared library packaging convention
mv -v %name.so %name.so.%version

%install
mkdir -p %buildroot%_bindir
install -Dpm 0755 .build/src/%import_path/%{sname}cli %buildroot%_bindir

mkdir -p %buildroot%_libdir
install -Dpm 0644 .build/src/%import_path/%name.so.%version %buildroot%_libdir
ln -sf %name.so.%version %buildroot%_libdir/%name.so

mkdir -p %buildroot%_pkgconfigdir
install -Dpm 0644 .build/src/%import_path/%oname.pc %buildroot%_pkgconfigdir

mkdir -p %buildroot%_includedir/%name
install -Dpm 0644 .build/src/%import_path/%name.h \
	%buildroot/%_includedir/%name
install -Dpm 0644 .build/src/%import_path/c-shared.h \
	%buildroot/%_includedir/%name
install -Dpm 0644 .build/src/%import_path/c-shared-util.h \
	%buildroot/%_includedir/%name
install -Dpm 0644 .build/src/%import_path/c-shared-varray.h \
	%buildroot/%_includedir/%name
```
As you can see, this is not ideal. The issue arises because you are using a shell script with sudo for installation instead of a Makefile. This is problematic since many build environments in various distributions do not have sudo, which makes your script unusable. Additionally, many users who want to build your project from source may not have sudo configured to avoid password prompts for every command. Personally, I would have to enter my password dozens of times to install your program. Moreover, elevating privileges for users is very unsafe, as compromising a less privileged user can compromise the entire system if they can escalate privileges.

Furthermore, many build environments in different distributions do not have git, so your project should not rely on fetching the version from git, as this breaks the build process. Additionally, your Makefile is heavily tied to predefined installation paths, which is not ideal. Different distributions may have different hierarchies; for example, libraries may be installed in /usr/lib or /usr/lib64, and so on.

I have added more flexibility to the Makefile using macros like DESTDIR, BINDIR, LIBDIR, etc. This is a common practice, as outlined in the GNU Coding Standards and RPM macros. I also fixed the packaging issue with the libraries; libgovarnam.so should be a symbolic link to libgovarnam.X.Y.Z, which is the standard practice across all distributions.

After my modifications, the Makefile and govarnam.pc allow the package build process to look like this:
```
%make_build

%install
cd .build/src/%import_path
%makeinstall_std PREFIX=%prefix \
        BINDIR=%_bindir \
        INCLUDEDIR=%_includedir \
        LIBDIR=%_libdir \
        PKGCONFIGDIR=%_pkgconfigdir
```
This is much better, isn't it?

```
Fix Makefile for library and program installation on Linux

- Added support for traditional Makefile macros:
    - DESTDIR
    - PREFIX
    - BINDIR
    - INCLUDEDIR
    - LIBDIR
    - PKGCONFIGDIR
- Program is now built under the 'all' pseudo-target
- Installation is now handled directly from the Makefile
- Removed requirement for sudo during installation
- Removed dependency on git during build
- Corrected the creation of the govarnam.pc file
- Improved code readability

Fix govarnam.pc file

- Used traditional macros:
    - @PREFIX@
    - @LIBDIR@
    - @INCLUDEDIR@
    ```