### PR TITLE
Drop `bool` typedef

### DIFF
--- a/c-shared-util.h
+++ b/c-shared-util.h
@@ -14,9 +14,10 @@
 #endif
 
 #ifndef __cplusplus
-  typedef int bool;
+#if __GNUC__ < 15
   #define false 0
   #define true  1
+#endif
 #endif
 
 #endif /* __UTIL_H__ */

--- a/c-shared-varray.c
+++ b/c-shared-varray.c
@@ -52,7 +52,7 @@ varray_length(varray *array)
     return array->index + 1;
 }
 
-bool
+int
 varray_is_empty (varray *array)
 {
     return (varray_length (array) == 0);
@@ -113,8 +113,8 @@ varray_insert(varray *array, int index, void *data)
     array->memory[index] = data;
 }
 
-bool
-varray_exists (varray *array, void *item, bool (*equals)(void *left, void *right))
+int
+varray_exists (varray *array, void *item, int (*equals)(void *left, void *right))
 {
     int i;
 

--- a/c-shared-varray.h
+++ b/c-shared-varray.h
@@ -24,11 +24,11 @@ varray_push(varray *array, void *data);
 VARNAM_EXPORT extern int
 varray_length(varray *array);
 
-VARNAM_EXPORT extern bool
+VARNAM_EXPORT extern int
 varray_is_empty (varray *array);
 
-VARNAM_EXPORT extern bool
-varray_exists (varray *array, void *item, bool (*equals)(void *left, void *right));
+VARNAM_EXPORT extern int
+varray_exists (varray *array, void *item, int (*equals)(void *left, void *right));
 
 VARNAM_EXPORT extern void
 varray_clear(varray *array);

--- a/c-shared.c
+++ b/c-shared.c
@@ -58,7 +58,7 @@ void destroyTransliterationResult(TransliterationResult* result)
   result = NULL;
 }
 
-SchemeDetails* makeSchemeDetails(char* Identifier, char* LangCode, char* DisplayName, char* Author, char* CompiledDate, bool IsStable)
+SchemeDetails* makeSchemeDetails(char* Identifier, char* LangCode, char* DisplayName, char* Author, char* CompiledDate, int IsStable)
 {
   SchemeDetails* sd = (SchemeDetails*) malloc (sizeof(SchemeDetails));
   sd->Identifier = Identifier;

--- a/c-shared.h
+++ b/c-shared.h
@@ -46,10 +46,10 @@ typedef struct SchemeDetails_t {
   char* DisplayName;
   char* Author;
   char* CompiledDate;
-  bool IsStable;
+  int   IsStable;
 } SchemeDetails;
 
-SchemeDetails* makeSchemeDetails(char* Identifier, char* LangCode, char* DisplayName, char* Author, char* CompiledDate, bool IsStable);
+SchemeDetails* makeSchemeDetails(char* Identifier, char* LangCode, char* DisplayName, char* Author, char* CompiledDate, int IsStable);
 
 void destroySchemeDetailsArray(void* cSchemeDetails);
 


### PR DESCRIPTION
GCC throws an error when a bool type is defined:

```
./c-shared-util.h:17:15: error: 'bool' cannot be defined via 'typedef'
   17 |   typedef int bool;
      |               ^~~~
./c-shared-util.h:17:15: note: 'bool' is a keyword with '-std=c23' onwards
```

Since bool and int don't need to be the same types at the ABI boundary we must replace `bool` by `int` there. We can still use `true` and `false` internally due to implicit type conversion.

Something like this will be needed to prevent varnam from dropping out of Debian. 